### PR TITLE
Update :rubygems

### DIFF
--- a/remote-liblouis/ruby/Gemfile
+++ b/remote-liblouis/ruby/Gemfile
@@ -1,4 +1,4 @@
-source:rubygems
+source "https://rubygems.org"
 
 gem "json"
 gem "sinatra"


### PR DESCRIPTION
Using the `:rubygems` symbol is deprecated. Update to use a secure connection to the servers.
